### PR TITLE
Fix DTOs and mappers alignment

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/PlayerDTO.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/PlayerDTO.java
@@ -4,7 +4,10 @@ import lombok.Data;
 
 @Data
 public class PlayerDTO {
+    private Long id;
     private String steamId;
-    private String telegramUsername;
-    private String discordUsername;
+    private String username;
+    private String telegram;
+    private String discord;
+    private Long teamId;
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/TeamDTO.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/TeamDTO.java
@@ -19,4 +19,6 @@ public class TeamDTO {
 
     @NotNull(message = "Tournament ID is required")
     private Long tournamentId;
+
+    private java.util.List<PlayerDTO> players;
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/MatchMapper.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/MatchMapper.java
@@ -25,6 +25,7 @@ public class MatchMapper {
     }
 
     public static List<MatchDTO> toDtoList(List<Match> matches) {
+        if (matches == null) return java.util.Collections.emptyList();
         return matches.stream()
                 .map(MatchMapper::toDto)
                 .collect(Collectors.toList());

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/PlayerMapper.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/PlayerMapper.java
@@ -2,6 +2,7 @@ package com.example.syrax_tournament_backend.mapper;
 
 import com.example.syrax_tournament_backend.dto.PlayerDTO;
 import com.example.syrax_tournament_backend.model.Player;
+import com.example.syrax_tournament_backend.model.Team;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,22 +10,33 @@ import java.util.stream.Collectors;
 public class PlayerMapper {
 
     public static PlayerDTO toDto(Player player) {
+        if (player == null) return null;
         PlayerDTO dto = new PlayerDTO();
+        dto.setId(player.getId());
         dto.setSteamId(player.getSteamId());
-        dto.setTelegramUsername(player.getTelegram());
-        dto.setDiscordUsername(player.getDiscord());
+        dto.setUsername(player.getUsername());
+        dto.setTelegram(player.getTelegram());
+        dto.setDiscord(player.getDiscord());
+        dto.setTeamId(player.getTeam() != null ? player.getTeam().getId() : null);
         return dto;
     }
 
     public static Player toEntity(PlayerDTO dto) {
+        if (dto == null) return null;
         Player player = new Player();
+        player.setId(dto.getId());
         player.setSteamId(dto.getSteamId());
-        player.setTelegram(dto.getTelegramUsername());
-        player.setDiscord(dto.getDiscordUsername());
+        player.setUsername(dto.getUsername());
+        player.setTelegram(dto.getTelegram());
+        player.setDiscord(dto.getDiscord());
+        if (dto.getTeamId() != null) {
+            player.setTeam(Team.builder().id(dto.getTeamId()).build());
+        }
         return player;
     }
 
     public static List<PlayerDTO> toDtoList(List<Player> players) {
+        if (players == null) return java.util.Collections.emptyList();
         return players.stream()
                 .map(PlayerMapper::toDto)
                 .collect(Collectors.toList());

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/TeamMapper.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/TeamMapper.java
@@ -3,6 +3,7 @@ package com.example.syrax_tournament_backend.mapper;
 
 import com.example.syrax_tournament_backend.dto.TeamDTO;
 import com.example.syrax_tournament_backend.model.Team;
+import com.example.syrax_tournament_backend.model.Tournament;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +17,8 @@ public class TeamMapper {
                 .name(team.getName())
                 .logoUrl(team.getLogoUrl())
                 .ownerSteamId(team.getOwnerSteamId())
+                .tournamentId(team.getTournament() != null ? team.getTournament().getId() : null)
+                .players(PlayerMapper.toDtoList(team.getPlayers()))
                 .build();
     }
 
@@ -34,12 +37,36 @@ public class TeamMapper {
         if (dto.getId() != null) {
             builder.id(dto.getId());
         }
+        if (dto.getTournamentId() != null) {
+            builder.tournament(Tournament.builder().id(dto.getTournamentId()).build());
+        }
+        if (dto.getPlayers() != null) {
+            builder.players(dto.getPlayers().stream()
+                    .map(PlayerMapper::toEntity)
+                    .collect(Collectors.toList()));
+        }
         return builder.build();
+    }
+
+    public static Team toEntity(TeamDTO dto, Tournament tournament) {
+        Team team = toEntity(dto);
+        if (team != null) {
+            team.setTournament(tournament);
+        }
+        return team;
     }
 
     public static void updateEntity(Team existing, TeamDTO dto) {
         if (dto.getName() != null) existing.setName(dto.getName());
         if (dto.getLogoUrl() != null) existing.setLogoUrl(dto.getLogoUrl());
         if (dto.getOwnerSteamId() != null) existing.setOwnerSteamId(dto.getOwnerSteamId());
+        if (dto.getTournamentId() != null) {
+            existing.setTournament(Tournament.builder().id(dto.getTournamentId()).build());
+        }
+        if (dto.getPlayers() != null) {
+            existing.setPlayers(dto.getPlayers().stream()
+                    .map(PlayerMapper::toEntity)
+                    .collect(Collectors.toList()));
+        }
     }
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/TournamentMapper.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/TournamentMapper.java
@@ -6,8 +6,6 @@ import com.example.syrax_tournament_backend.mapper.TeamMapper;
 import com.example.syrax_tournament_backend.mapper.MatchMapper;
 
 import com.example.syrax_tournament_backend.dto.TournamentDTO;
-import com.example.syrax_tournament_backend.model.Match;
-import com.example.syrax_tournament_backend.model.Team;
 import com.example.syrax_tournament_backend.model.Tournament;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,7 +64,7 @@ public class TournamentMapper {
         if (dto.getTeams() != null) {
             builder.teams(
                     dto.getTeams().stream()
-                            .map(teamDto -> Team.builder().id(teamDto.getId()).build())
+                            .map(TeamMapper::toEntity)
                             .collect(Collectors.toList())
             );
         }
@@ -74,7 +72,7 @@ public class TournamentMapper {
         if (dto.getMatches() != null) {
             builder.matches(
                     dto.getMatches().stream()
-                            .map(matchDto -> Match.builder().id(matchDto.getId()).build())
+                            .map(MatchMapper::toEntity)
                             .collect(Collectors.toList())
             );
         }
@@ -93,7 +91,7 @@ public class TournamentMapper {
         if (dto.getTeams() != null) {
             existing.setTeams(
                     dto.getTeams().stream()
-                            .map(teamDto -> Team.builder().id(teamDto.getId()).build())
+                            .map(TeamMapper::toEntity)
                             .collect(Collectors.toList())
             );
         }
@@ -101,7 +99,7 @@ public class TournamentMapper {
         if (dto.getMatches() != null) {
             existing.setMatches(
                     dto.getMatches().stream()
-                            .map(matchDto -> Match.builder().id(matchDto.getId()).build())
+                            .map(MatchMapper::toEntity)
                             .collect(Collectors.toList())
             );
         }


### PR DESCRIPTION
## Summary
- sync DTO classes with entity fields
- update player, team, match and tournament mappers with null checks
- enable full mapping support including nested IDs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ef81e37bc832cb0ae203c2e86d820