### PR TITLE
Return ResponseEntity from tournament endpoints

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TournamentController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TournamentController.java
@@ -7,6 +7,7 @@ import com.example.syrax_tournament_backend.repository.TournamentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,27 +33,28 @@ public class TournamentController {
     }
 
     @GetMapping("/{id}")
-    public TournamentDTO getTournamentById(@PathVariable Long id) {
+    public ResponseEntity<TournamentDTO> getTournamentById(@PathVariable Long id) {
         Tournament entity = tournamentRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Tournament not found with id " + id));
-        return TournamentMapper.toDto(entity);
+        return ResponseEntity.ok(TournamentMapper.toDto(entity));
     }
 
     @PostMapping(
             consumes = MediaType.APPLICATION_JSON_VALUE
     )
-    @ResponseStatus(HttpStatus.CREATED)
-    public TournamentDTO createTournament(@Valid @RequestBody TournamentDTO dto) {
+    public ResponseEntity<TournamentDTO> createTournament(@Valid @RequestBody TournamentDTO dto) {
         Tournament toSave = TournamentMapper.toEntity(dto);
         Tournament saved  = tournamentRepository.save(toSave);
-        return TournamentMapper.toDto(saved);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(TournamentMapper.toDto(saved));
     }
 
     @PutMapping(
             path = "/{id}",
             consumes = MediaType.APPLICATION_JSON_VALUE
     )
-    public TournamentDTO updateTournament(
+    public ResponseEntity<TournamentDTO> updateTournament(
             @PathVariable Long id,
             @Valid @RequestBody TournamentDTO dto
     ) {
@@ -62,7 +64,7 @@ public class TournamentController {
         // copy over only the non-null fields
         TournamentMapper.updateEntity(existing, dto);
         Tournament updated = tournamentRepository.save(existing);
-        return TournamentMapper.toDto(updated);
+        return ResponseEntity.ok(TournamentMapper.toDto(updated));
     }
 
     @DeleteMapping("/{id}")


### PR DESCRIPTION
## Summary
- adjust `TournamentController` to wrap responses with `ResponseEntity`
- set `CREATED` status code when creating tournaments

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686efefb66f8832c97ea71bce0189b28