### PR TITLE
Add global exception handler

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/advice/GlobalExceptionHandler.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/advice/GlobalExceptionHandler.java
@@ -2,20 +2,25 @@ package com.example.syrax_tournament_backend.advice;
 
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RestControllerAdvice
+@ControllerAdvice
 public class GlobalExceptionHandler {
 
     // handle @Valid request‐body bean validation failures
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
     public Map<String, String> handleMethodArgNotValid(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
@@ -27,6 +32,7 @@ public class GlobalExceptionHandler {
     // handle @Validated on controller method parameters (e.g. @RequestParam, @PathVariable)
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
     public Map<String, String> handleConstraintViolation(ConstraintViolationException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getConstraintViolations().forEach(cv ->
@@ -38,14 +44,14 @@ public class GlobalExceptionHandler {
     // catch malformed JSON, wrong content‐type, etc.
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
     public Map<String, String> handleBadJson(HttpMessageNotReadableException ex) {
         return Map.of("error", "Malformed request body");
     }
 
     // fallback for not‐found or other RuntimeExceptions you throw
     @ExceptionHandler(RuntimeException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Map<String, String> handleNotFound(RuntimeException ex) {
-        return Map.of("error", ex.getMessage());
+    public ResponseEntity<String> handleRuntimeException(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 import java.util.List;
@@ -31,10 +30,7 @@ public class MatchController {
     )
     public MatchDTO getMatchById(@PathVariable Long id) {
         Match m = matchRepository.findById(id)
-                .orElseThrow(() ->
-                        new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                "Match not found with id " + id)
-                );
+                .orElseThrow(() -> new RuntimeException("Match not found with id " + id));
         return MatchMapper.toDto(m);
     }
 
@@ -58,10 +54,7 @@ public class MatchController {
             @Valid @RequestBody MatchDTO dto
     ) {
         Match existing = matchRepository.findById(id)
-                .orElseThrow(() ->
-                        new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                "Match not found with id " + id)
-                );
+                .orElseThrow(() -> new RuntimeException("Match not found with id " + id));
         MatchMapper.updateEntity(existing, dto);
         Match updated = matchRepository.save(existing);
         return MatchMapper.toDto(updated);
@@ -71,8 +64,7 @@ public class MatchController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteMatch(@PathVariable Long id) {
         if (!matchRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "Match not found with id " + id);
+            throw new RuntimeException("Match not found with id " + id);
         }
         matchRepository.deleteById(id);
     }


### PR DESCRIPTION
## Summary
- convert `GlobalExceptionHandler` to `@ControllerAdvice`
- return a 404 `ResponseEntity` for any `RuntimeException`
- use `RuntimeException` in `MatchController` instead of `ResponseStatusException`

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686eff148abc832cbf60aaf0ddde6422