### PR TITLE
Simplify exception logic in TournamentController

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TournamentController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TournamentController.java
@@ -68,9 +68,8 @@ public class TournamentController {
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteTournament(@PathVariable Long id) {
-        if (!tournamentRepository.existsById(id)) {
-            throw new RuntimeException("Tournament not found with id " + id);
-        }
-        tournamentRepository.deleteById(id);
+        Tournament existing = tournamentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id " + id));
+        tournamentRepository.delete(existing);
     }
 }


### PR DESCRIPTION
## Summary
- delegate not-found responses to GlobalExceptionHandler
- remove manual checks in `deleteTournament`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eff27b380832c88b678cf56d9325b