### PR TITLE
Update getTeamsByTournament to return DTOs

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TeamController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TeamController.java
@@ -34,9 +34,10 @@ public class TeamController {
     }
 
     @GetMapping("/tournament/{tournamentId}")
-    public ResponseEntity<List<Team>> getTeamsByTournament(@PathVariable Long tournamentId) {
+    public ResponseEntity<List<TeamDTO>> getTeamsByTournament(@PathVariable Long tournamentId) {
         Tournament tournament = tournamentRepository.findById(tournamentId)
                 .orElseThrow(() -> new RuntimeException("Tournament not found"));
-        return ResponseEntity.ok(tournament.getTeams());
+        List<TeamDTO> teamDTOs = TeamMapper.toDtoList(tournament.getTeams());
+        return ResponseEntity.ok(teamDTOs);
     }
 }


### PR DESCRIPTION
## Summary
- convert `Team` list to `TeamDTO` list using `TeamMapper` in `getTeamsByTournament`
- return `ResponseEntity.ok()` with the DTO list

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f02f97ce8832ca2323cad78f7cedb