### PR TITLE
Fix team DTO validation

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TeamController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/TeamController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
+
 import java.util.List;
 
 @RestController
@@ -22,7 +24,7 @@ public class TeamController {
     private final TournamentRepository tournamentRepository;
 
     @PostMapping
-    public ResponseEntity<TeamDTO> createTeam(@RequestBody TeamDTO dto) {
+    public ResponseEntity<TeamDTO> createTeam(@Valid @RequestBody TeamDTO dto) {
         Tournament tournament = tournamentRepository.findById(dto.getTournamentId())
                 .orElseThrow(() -> new RuntimeException("Tournament not found"));
 


### PR DESCRIPTION
## Summary
- validate the team DTO in `createTeam`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f03ccb350832ca141d9707210c3c7