### PR TITLE
Refactor PlayerController to use DTOs and ResponseEntity

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/PlayerMapper.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/mapper/PlayerMapper.java
@@ -35,6 +35,14 @@ public class PlayerMapper {
         return player;
     }
 
+    public static Player toEntity(PlayerDTO dto, Team team) {
+        Player player = toEntity(dto);
+        if (player != null) {
+            player.setTeam(team);
+        }
+        return player;
+    }
+
     public static List<PlayerDTO> toDtoList(List<Player> players) {
         if (players == null) return java.util.Collections.emptyList();
         return players.stream()


### PR DESCRIPTION
## Summary
- use TeamRepository in PlayerController and createPlayer to look up teams
- return `ResponseEntity` in PlayerController methods and set `CREATED` on create
- add `@Valid` to POST endpoint
- add PlayerMapper helper to convert using an explicit Team

## Testing
- `./mvnw -q test` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f056e0a68832ca510d3cbe899248b