### PR TITLE
Refactor AdminController for REST style

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/AdminController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/AdminController.java
@@ -1,13 +1,18 @@
 package com.example.syrax_tournament_backend.controller;
 
+import com.example.syrax_tournament_backend.dto.AdminMessage;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+// import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
+@RequestMapping("/api/admin")
 public class AdminController {
 
-    @GetMapping("/admin")
-    public String adminHome() {
-        return "Welcome, Admin!";
+    @GetMapping
+    // @PreAuthorize("hasRole('ADMIN')")
+    public AdminMessage adminHome() {
+        return new AdminMessage("Welcome, Admin!");
     }
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/AdminMessage.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/dto/AdminMessage.java
@@ -1,0 +1,10 @@
+package com.example.syrax_tournament_backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AdminMessage {
+    private String message;
+}


### PR DESCRIPTION
## Summary
- add `AdminMessage` DTO for controller responses
- refactor `AdminController` to use `/api/admin` prefix and return `AdminMessage`
- comment out `@PreAuthorize` for future security use

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686f07fe954c832c9a4bf43d37327fb6