### PR TITLE
Adjust MatchController responses

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
@@ -7,6 +7,7 @@ import com.example.syrax_tournament_backend.repository.MatchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -28,20 +29,19 @@ public class MatchController {
             path = "/{id}",
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public MatchDTO getMatchById(@PathVariable Long id) {
+    public ResponseEntity<MatchDTO> getMatchById(@PathVariable Long id) {
         Match m = matchRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Match not found with id " + id));
-        return MatchMapper.toDto(m);
+        return ResponseEntity.ok(MatchMapper.toDto(m));
     }
 
     @PostMapping(
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ResponseStatus(HttpStatus.CREATED)
-    public MatchDTO createMatch(@Valid @RequestBody MatchDTO dto) {
+    public ResponseEntity<MatchDTO> createMatch(@Valid @RequestBody MatchDTO dto) {
         Match saved = matchRepository.save(MatchMapper.toEntity(dto));
-        return MatchMapper.toDto(saved);
+        return ResponseEntity.status(HttpStatus.CREATED).body(MatchMapper.toDto(saved));
     }
 
     @PutMapping(
@@ -49,7 +49,7 @@ public class MatchController {
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public MatchDTO updateMatch(
+    public ResponseEntity<MatchDTO> updateMatch(
             @PathVariable Long id,
             @Valid @RequestBody MatchDTO dto
     ) {
@@ -57,15 +57,15 @@ public class MatchController {
                 .orElseThrow(() -> new RuntimeException("Match not found with id " + id));
         MatchMapper.updateEntity(existing, dto);
         Match updated = matchRepository.save(existing);
-        return MatchMapper.toDto(updated);
+        return ResponseEntity.ok(MatchMapper.toDto(updated));
     }
 
     @DeleteMapping("/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMatch(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteMatch(@PathVariable Long id) {
         if (!matchRepository.existsById(id)) {
             throw new RuntimeException("Match not found with id " + id);
         }
         matchRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/exception/GlobalExceptionHandler.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.example.syrax_tournament_backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
+        Map<String, String> body = new HashMap<>();
+        body.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap MatchController endpoints with `ResponseEntity`
- send `201 CREATED` for POST requests
- return `204 NO CONTENT` for delete
- add global `RuntimeException` handler that returns JSON

## Testing
- `./mvnw -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f0aba9b7c832ca1c27ba88678cd51