### PR TITLE
Fix return type for getAllMatches

### DIFF
--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/controller/MatchController.java
@@ -21,8 +21,9 @@ public class MatchController {
     private final MatchRepository matchRepository;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<MatchDTO> getAllMatches() {
-        return MatchMapper.toDtoList(matchRepository.findAll());
+    public ResponseEntity<List<MatchDTO>> getAllMatches() {
+        List<MatchDTO> matches = MatchMapper.toDtoList(matchRepository.findAll());
+        return ResponseEntity.ok(matches);
     }
 
     @GetMapping(


### PR DESCRIPTION
## Summary
- return `ResponseEntity<List<MatchDTO>>` from `getAllMatches`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ca75f1c832c91f91a7fa75b501e