### PR TITLE
Add delete button for tournaments

### DIFF
--- a/frontend/src/pages/TournamentsPage.jsx
+++ b/frontend/src/pages/TournamentsPage.jsx
@@ -6,6 +6,18 @@ function TournamentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const handleDelete = async (id) => {
+    const confirmDelete = window.confirm('Are you sure you want to delete this tournament?');
+    if (!confirmDelete) return;
+    try {
+      await api.delete(`/tournaments/${id}`);
+      setTournaments((prev) => prev.filter((t) => t.id !== id));
+    } catch (err) {
+      console.error(err);
+      alert('Failed to delete tournament');
+    }
+  };
+
   useEffect(() => {
     async function fetchTournaments() {
       try {
@@ -35,7 +47,15 @@ function TournamentsPage() {
       <ul className="space-y-2">
         {tournaments.map((tournament) => (
           <li key={tournament.id} className="border p-4 rounded">
-            <div className="font-bold">{tournament.name}</div>
+            <div className="font-bold flex items-center justify-between">
+              <span>{tournament.name}</span>
+              <button
+                onClick={() => handleDelete(tournament.id)}
+                className="text-red-500 hover:text-red-700 text-sm"
+              >
+                Delete
+              </button>
+            </div>
             <div>Status: {tournament.status}</div>
             <div>Game: {tournament.game}</div>
             <div>Start Time: {tournament.startTime}</div>


### PR DESCRIPTION
## Summary
- add client-side deletion for tournaments via API
- add confirmation dialog and remove from state

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3d667778832caf7108890b3ef7fd