### PR TITLE
Add tournament routes and navigation links

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Admin from './pages/Admin';
 import Teams from './pages/Teams';
+import TournamentsPage from './pages/TournamentsPage.jsx';
+import TournamentDetails from './pages/TournamentDetails.jsx';
 
 function App() {
   return (
@@ -16,6 +18,8 @@ function App() {
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/admin" element={<Admin />} />
         <Route path="/teams" element={<Teams />} />
+        <Route path="/tournaments" element={<TournamentsPage />} />
+        <Route path="/tournaments/:id" element={<TournamentDetails />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -39,6 +39,9 @@ function Navbar() {
               <Link to="/" className="hover:underline">
                 Home
               </Link>
+              <Link to="/tournaments" className="hover:underline">
+                Tournaments
+              </Link>
               <Link to="/create" className="hover:underline">
                 Create Tournament
               </Link>
@@ -53,6 +56,12 @@ function Navbar() {
         <div className="px-2 pt-2 pb-3 space-y-1 md:hidden">
           <Link to="/" className="block px-3 py-2 hover:bg-gray-700 rounded-md">
             Home
+          </Link>
+          <Link
+            to="/tournaments"
+            className="block px-3 py-2 hover:bg-gray-700 rounded-md"
+          >
+            Tournaments
           </Link>
           <Link
             to="/create"


### PR DESCRIPTION
## Summary
- wire up tournament pages in the router
- expose tournament pages via the navbar

## Testing
- `npm test --silent --maxWorkers=50` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686f44d70e58832cbd22cd0e02888c90