### PR TITLE
Update security admin path

### DIFF
--- a/syrax-tournament-backend/pom.xml
+++ b/syrax-tournament-backend/pom.xml
@@ -59,11 +59,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/config/SecurityConfig.java
+++ b/syrax-tournament-backend/src/main/java/com/example/syrax_tournament_backend/config/SecurityConfig.java
@@ -21,12 +21,12 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/admin/**").authenticated()
+                        .requestMatchers("/api/admin/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .authenticationProvider(authenticationProvider())  // ✅ This is required
                 .formLogin(login -> login
-                        .defaultSuccessUrl("/admin", true)
+                        .defaultSuccessUrl("/api/admin", true)
                         .permitAll()
                 )
                 .logout(logout -> logout

--- a/syrax-tournament-backend/src/test/java/com/example/syrax_tournament_backend/LoginRedirectTest.java
+++ b/syrax-tournament-backend/src/test/java/com/example/syrax_tournament_backend/LoginRedirectTest.java
@@ -1,0 +1,52 @@
+package com.example.syrax_tournament_backend;
+
+import com.example.syrax_tournament_backend.model.Admin;
+import com.example.syrax_tournament_backend.repository.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class LoginRedirectTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setupAdmin() {
+        adminRepository.deleteAll();
+        Admin admin = new Admin();
+        admin.setUsername("syraxadmin");
+        admin.setPassword(passwordEncoder.encode("admin123"));
+        adminRepository.save(admin);
+    }
+
+    @Test
+    void loginRedirectsToAdminApi() throws Exception {
+        mockMvc.perform(post("/login")
+                        .param("username", "syraxadmin")
+                        .param("password", "admin123"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/api/admin"));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce `/api/admin/**` authorization rules
- redirect successful login to `/api/admin`
- verify login redirect with a new test
- add H2 DB for testing

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f44d341b0832c84e2a51dab6c2843